### PR TITLE
Create login and registration pages with shared styling

### DIFF
--- a/Styles/auth.css
+++ b/Styles/auth.css
@@ -1,0 +1,202 @@
+:root {
+    --bg: #0f172a;
+    --bg-secondary: #1e293b;
+    --surface: #ffffff;
+    --surface-alt: #f8fafc;
+    --accent: #f97316;
+    --accent-dark: #ea580c;
+    --text: #0f172a;
+    --text-muted: #475569;
+    --border: rgba(15, 23, 42, 0.08);
+    --radius-lg: 24px;
+    --radius-md: 18px;
+    --radius-sm: 12px;
+    font-size: 16px;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: "Manrope", sans-serif;
+    background: linear-gradient(180deg, var(--bg) 0%, #16213a 100%);
+    color: var(--surface);
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 48px 16px;
+}
+
+main {
+    width: min(420px, 100%);
+}
+
+.auth-card {
+    background: rgba(15, 23, 42, 0.75);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(12px);
+    border-radius: var(--radius-lg);
+    padding: 40px 36px;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+    box-shadow: 0 24px 48px rgba(15, 23, 42, 0.4);
+}
+
+.brand {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    font-weight: 700;
+    font-size: 1.35rem;
+    letter-spacing: 0.01em;
+    color: #fff;
+}
+
+.brand-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 14px;
+    background: linear-gradient(135deg, #38bdf8, #6366f1);
+    position: relative;
+}
+
+.brand-icon::after {
+    content: "";
+    position: absolute;
+    inset: 8px;
+    border-radius: 10px;
+    border: 2px solid rgba(255, 255, 255, 0.6);
+}
+
+.auth-header {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.auth-header h1 {
+    font-size: clamp(1.75rem, 4vw, 2.25rem);
+    color: #fff;
+}
+
+.auth-header p {
+    color: rgba(255, 255, 255, 0.72);
+    line-height: 1.5;
+}
+
+form {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+label {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: rgba(248, 250, 252, 0.9);
+}
+
+input[type="text"],
+input[type="email"],
+input[type="password"] {
+    padding: 14px 16px;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(248, 250, 252, 0.18);
+    background: rgba(15, 23, 42, 0.48);
+    color: #fff;
+    font-size: 1rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus {
+    outline: none;
+    border-color: rgba(99, 102, 241, 0.6);
+    box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.18);
+}
+
+input::placeholder {
+    color: rgba(148, 163, 184, 0.75);
+}
+
+.actions {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 14px;
+    border-radius: 999px;
+    border: none;
+    font-weight: 600;
+    font-size: 1rem;
+    color: #fff;
+    background: var(--accent);
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.button:hover,
+.button:focus {
+    transform: translateY(-1px);
+    box-shadow: 0 18px 28px rgba(15, 23, 42, 0.3);
+    background: var(--accent-dark);
+}
+
+.auxiliary {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+.auxiliary a {
+    color: #38bdf8;
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.auxiliary a:hover,
+.auxiliary a:focus {
+    text-decoration: underline;
+}
+
+.inline {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    font-size: 0.9rem;
+    color: rgba(248, 250, 252, 0.72);
+}
+
+input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    accent-color: var(--accent);
+}
+
+@media (max-width: 520px) {
+    body {
+        padding: 32px 16px;
+    }
+
+    .auth-card {
+        padding: 32px 24px;
+    }
+}

--- a/pages/login.html
+++ b/pages/login.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="es">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <title>AutoServ · Iniciar Sesión</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="description" content="Inicia sesión para gestionar tus servicios automotrices." />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap"
+            rel="stylesheet"
+        />
+        <link rel="stylesheet" href="../Styles/auth.css" />
+    </head>
+    <body>
+        <main>
+            <section class="auth-card" aria-labelledby="login-title">
+                <div class="brand" aria-label="AutoServ">
+                    <div class="brand-icon" aria-hidden="true"></div>
+                    <span>AutoServ</span>
+                </div>
+
+                <header class="auth-header">
+                    <h1 id="login-title">Bienvenido de nuevo</h1>
+                    <p>Accede a tu cuenta para agendar citas, enviar mensajes y revisar tu historial.</p>
+                </header>
+
+                <form>
+                    <div class="field">
+                        <label for="email">Correo electrónico</label>
+                        <input
+                            type="email"
+                            id="email"
+                            name="email"
+                            placeholder="nombre@correo.com"
+                            autocomplete="email"
+                            required
+                        />
+                    </div>
+                    <div class="field">
+                        <label for="password">Contraseña</label>
+                        <input
+                            type="password"
+                            id="password"
+                            name="password"
+                            placeholder="Ingresa tu contraseña"
+                            autocomplete="current-password"
+                            required
+                        />
+                    </div>
+                    <div class="inline">
+                        <label for="remember">
+                            <input type="checkbox" id="remember" name="remember" /> Recuérdame
+                        </label>
+                        <a href="#">¿Olvidaste tu contraseña?</a>
+                    </div>
+                    <div class="actions">
+                        <button type="submit" class="button">Iniciar sesión</button>
+                    </div>
+                </form>
+
+                <div class="auxiliary">
+                    <span>¿Aún no tienes una cuenta?</span>
+                    <a href="./registro.html">Crear cuenta</a>
+                </div>
+            </section>
+        </main>
+    </body>
+</html>

--- a/pages/registro.html
+++ b/pages/registro.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="es">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <title>AutoServ · Crear Cuenta</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="description" content="Regístrate para aprovechar los servicios de AutoServ." />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap"
+            rel="stylesheet"
+        />
+        <link rel="stylesheet" href="../Styles/auth.css" />
+    </head>
+    <body>
+        <main>
+            <section class="auth-card" aria-labelledby="register-title">
+                <div class="brand" aria-label="AutoServ">
+                    <div class="brand-icon" aria-hidden="true"></div>
+                    <span>AutoServ</span>
+                </div>
+
+                <header class="auth-header">
+                    <h1 id="register-title">Crea tu cuenta</h1>
+                    <p>Completa tus datos para empezar a agendar servicios y recibir soporte personalizado.</p>
+                </header>
+
+                <form>
+                    <div class="field">
+                        <label for="name">Nombre completo</label>
+                        <input
+                            type="text"
+                            id="name"
+                            name="name"
+                            placeholder="Tu nombre"
+                            autocomplete="name"
+                            required
+                        />
+                    </div>
+                    <div class="field">
+                        <label for="email">Correo electrónico</label>
+                        <input
+                            type="email"
+                            id="email"
+                            name="email"
+                            placeholder="nombre@correo.com"
+                            autocomplete="email"
+                            required
+                        />
+                    </div>
+                    <div class="field">
+                        <label for="password">Contraseña</label>
+                        <input
+                            type="password"
+                            id="password"
+                            name="password"
+                            placeholder="Crea una contraseña"
+                            autocomplete="new-password"
+                            required
+                        />
+                    </div>
+                    <div class="field">
+                        <label for="confirm-password">Confirmar contraseña</label>
+                        <input
+                            type="password"
+                            id="confirm-password"
+                            name="confirm-password"
+                            placeholder="Repite tu contraseña"
+                            autocomplete="new-password"
+                            required
+                        />
+                    </div>
+                    <div class="actions">
+                        <button type="submit" class="button">Registrarme</button>
+                    </div>
+                </form>
+
+                <div class="auxiliary">
+                    <span>¿Ya tienes cuenta?</span>
+                    <a href="./login.html">Inicia sesión</a>
+                </div>
+            </section>
+        </main>
+    </body>
+</html>


### PR DESCRIPTION
## Summary
- add a shared authentication stylesheet that matches the existing AutoServ aesthetic
- create a dedicated login page with email, password and recovery links
- add a registration page with fields for name, email and password confirmation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d214866b44832dacaae2f8f68b6359