### PR TITLE
Agregar selección de tipo de cuenta y certificado en registro

### DIFF
--- a/Styles/auth.css
+++ b/Styles/auth.css
@@ -109,7 +109,9 @@ label {
 
 input[type="text"],
 input[type="email"],
-input[type="password"] {
+input[type="password"],
+input[type="file"],
+select {
     padding: 14px 16px;
     border-radius: var(--radius-sm);
     border: 1px solid rgba(248, 250, 252, 0.18);
@@ -127,6 +129,21 @@ input:focus {
 
 input::placeholder {
     color: rgba(148, 163, 184, 0.75);
+}
+
+select {
+    appearance: none;
+    cursor: pointer;
+    background-image: linear-gradient(45deg, transparent 50%, rgba(148, 163, 184, 0.75) 50%),
+        linear-gradient(135deg, rgba(148, 163, 184, 0.75) 50%, transparent 50%);
+    background-position: calc(100% - 20px) calc(50% - 4px), calc(100% - 14px) calc(50% - 4px);
+    background-size: 6px 6px, 6px 6px;
+    background-repeat: no-repeat;
+    padding-right: 40px;
+}
+
+input[type="file"] {
+    cursor: pointer;
 }
 
 .actions {
@@ -193,6 +210,10 @@ input[type="checkbox"] {
     width: 18px;
     height: 18px;
     accent-color: var(--accent);
+}
+
+.hidden {
+    display: none;
 }
 
 @media (max-width: 520px) {

--- a/pages/registro.html
+++ b/pages/registro.html
@@ -72,6 +72,24 @@
                             required
                         />
                     </div>
+                    <div class="field">
+                        <label for="account-type">Tipo de cuenta</label>
+                        <select id="account-type" name="account-type" required>
+                            <option value="" disabled selected>Selecciona una opción</option>
+                            <option value="cliente">Cliente</option>
+                            <option value="mecanico">Mecánico</option>
+                        </select>
+                    </div>
+                    <div class="field hidden" id="certificate-field">
+                        <label for="certificate">Certificado profesional (foto)</label>
+                        <input
+                            type="file"
+                            id="certificate"
+                            name="certificate"
+                            accept="image/*"
+                        />
+                        <p class="hint">Sube una foto legible de tu certificación como mecánico.</p>
+                    </div>
                     <div class="actions">
                         <button type="submit" class="button">Registrarme</button>
                     </div>
@@ -83,5 +101,27 @@
                 </div>
             </section>
         </main>
+
+        <script>
+            const accountType = document.getElementById("account-type");
+            const certificateField = document.getElementById("certificate-field");
+            const certificateInput = document.getElementById("certificate");
+
+            if (accountType) {
+                accountType.addEventListener("change", () => {
+                    const isMechanic = accountType.value === "mecanico";
+
+                    certificateField?.classList.toggle("hidden", !isMechanic);
+
+                    if (certificateInput) {
+                        certificateInput.required = isMechanic;
+
+                        if (!isMechanic) {
+                            certificateInput.value = "";
+                        }
+                    }
+                });
+            }
+        </script>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- agregar selección obligatoria del tipo de cuenta entre cliente y mecánico en el formulario de registro
- mostrar campo para cargar certificado profesional cuando se elige la opción de mecánico
- actualizar estilos para selectores y campos de carga de archivos manteniendo la apariencia del formulario

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d33e62f274832dacaf1e22c3a83101