### PR TITLE
Add user profile page and navigation links

### DIFF
--- a/Styles/auth.css
+++ b/Styles/auth.css
@@ -50,11 +50,38 @@ main {
 .brand {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     gap: 14px;
     font-weight: 700;
     font-size: 1.35rem;
     letter-spacing: 0.01em;
     color: #fff;
+    width: 100%;
+}
+
+.brand-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 14px;
+    color: inherit;
+    text-decoration: none;
+}
+
+.brand-link:hover,
+.brand-link:focus {
+    text-decoration: underline;
+}
+
+.back-home {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #38bdf8;
+    text-decoration: none;
+}
+
+.back-home:hover,
+.back-home:focus {
+    text-decoration: underline;
 }
 
 .brand-icon {

--- a/Styles/paginainicio.css
+++ b/Styles/paginainicio.css
@@ -80,6 +80,16 @@ main {
     justify-content: center;
 }
 
+.header-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.header-actions .button {
+    white-space: nowrap;
+}
+
 .nav-link {
     color: rgba(255, 255, 255, 0.72);
     text-decoration: none;
@@ -338,6 +348,17 @@ main {
     .main-nav {
         justify-content: flex-start;
         flex-wrap: wrap;
+    }
+
+    .header-actions {
+        width: 100%;
+        justify-content: flex-start;
+        flex-wrap: wrap;
+        gap: 10px;
+    }
+
+    .header-actions .button {
+        flex: 1 1 160px;
     }
 
     .section-header {

--- a/Styles/perfil.css
+++ b/Styles/perfil.css
@@ -1,0 +1,378 @@
+:root {
+    --bg: #0f172a;
+    --bg-secondary: #1e293b;
+    --surface: #ffffff;
+    --surface-alt: #f8fafc;
+    --accent: #f97316;
+    --accent-dark: #ea580c;
+    --text: #0f172a;
+    --text-muted: #475569;
+    --border: rgba(15, 23, 42, 0.08);
+    --radius-lg: 24px;
+    --radius-md: 18px;
+    --radius-sm: 12px;
+    font-size: 16px;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: "Manrope", sans-serif;
+    background: linear-gradient(180deg, var(--bg) 0%, #16213a 100%);
+    color: var(--surface);
+    min-height: 100vh;
+    padding: 40px 24px 64px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 32px;
+}
+
+main {
+    width: min(1120px, 100%);
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+}
+
+.site-header {
+    width: min(1120px, 100%);
+    background: rgba(15, 23, 42, 0.72);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(12px);
+    border-radius: var(--radius-lg);
+    padding: 18px 32px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 24px;
+}
+
+.brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    font-weight: 700;
+    font-size: 1.25rem;
+    color: #fff;
+    text-decoration: none;
+}
+
+.brand-icon {
+    width: 36px;
+    height: 36px;
+    border-radius: 12px;
+    background: linear-gradient(135deg, #38bdf8, #6366f1);
+    position: relative;
+}
+
+.brand-icon::after {
+    content: "";
+    position: absolute;
+    inset: 8px;
+    border-radius: 8px;
+    border: 2px solid rgba(255, 255, 255, 0.6);
+}
+
+.header-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 20px;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    font-weight: 600;
+    color: var(--text);
+    background: var(--surface);
+    text-decoration: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.button:hover,
+.button:focus {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 20px rgba(15, 23, 42, 0.18);
+}
+
+.button.ghost {
+    background: rgba(15, 23, 42, 0.04);
+    color: #fff;
+    border-color: rgba(248, 250, 252, 0.12);
+    box-shadow: none;
+}
+
+.profile-summary {
+    background: var(--surface);
+    color: var(--text);
+    border-radius: var(--radius-lg);
+    padding: 40px;
+    display: grid;
+    gap: 28px;
+    box-shadow: 0 24px 48px rgba(15, 23, 42, 0.18);
+    position: relative;
+}
+
+.profile-summary::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    border: 1px solid rgba(15, 23, 42, 0.06);
+    pointer-events: none;
+}
+
+.user-card {
+    display: flex;
+    gap: 24px;
+    align-items: center;
+}
+
+.avatar {
+    width: 84px;
+    height: 84px;
+    border-radius: 24px;
+    background: linear-gradient(135deg, #22d3ee, #6366f1);
+    display: grid;
+    place-items: center;
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.user-details {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.label {
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-weight: 600;
+    color: #6366f1;
+    font-size: 0.8rem;
+}
+
+.user-details h1 {
+    font-size: clamp(1.8rem, 3vw, 2.4rem);
+}
+
+.role {
+    color: var(--text-muted);
+    font-weight: 600;
+}
+
+.user-meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 16px;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+.user-meta dt {
+    font-weight: 600;
+    color: var(--text);
+}
+
+.metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 20px;
+}
+
+.metric-card {
+    background: var(--surface-alt);
+    border-radius: var(--radius-md);
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.metric-label {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+}
+
+.metric-value {
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--text);
+}
+
+.metric-caption {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+.section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    margin-bottom: 24px;
+}
+
+.section-header h2 {
+    color: #fff;
+    font-size: 1.4rem;
+}
+
+.section-header p {
+    color: rgba(248, 250, 252, 0.7);
+}
+
+.history,
+.scores {
+    background: rgba(15, 23, 42, 0.75);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: var(--radius-lg);
+    padding: 36px 40px;
+    box-shadow: 0 24px 48px rgba(15, 23, 42, 0.18);
+}
+
+.history-list {
+    display: grid;
+    gap: 20px;
+}
+
+.history-item {
+    background: rgba(15, 23, 42, 0.38);
+    border-radius: var(--radius-md);
+    padding: 20px 24px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    border: 1px solid rgba(248, 250, 252, 0.06);
+}
+
+.history-item h3 {
+    font-size: 1.1rem;
+    margin-bottom: 4px;
+}
+
+.item-meta {
+    color: rgba(248, 250, 252, 0.72);
+    font-size: 0.95rem;
+}
+
+.status {
+    padding: 6px 14px;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.status.success {
+    background: rgba(34, 197, 94, 0.15);
+    color: #4ade80;
+}
+
+.status.pending {
+    background: rgba(250, 204, 21, 0.15);
+    color: #facc15;
+}
+
+.scores-table {
+    display: grid;
+    gap: 14px;
+}
+
+.table-header,
+.table-row {
+    display: grid;
+    grid-template-columns: 2fr 2fr 1fr 1fr;
+    gap: 16px;
+    align-items: center;
+    padding: 16px 20px;
+    border-radius: var(--radius-sm);
+}
+
+.table-header {
+    background: rgba(248, 250, 252, 0.08);
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+}
+
+.table-row {
+    background: rgba(15, 23, 42, 0.45);
+    border: 1px solid rgba(248, 250, 252, 0.05);
+}
+
+.table-row .rating {
+    font-weight: 700;
+    color: #facc15;
+}
+
+.site-footer {
+    width: min(1120px, 100%);
+    text-align: center;
+    color: rgba(248, 250, 252, 0.72);
+    font-size: 0.95rem;
+}
+
+.site-footer a {
+    color: #38bdf8;
+    text-decoration: none;
+}
+
+.site-footer a:hover,
+.site-footer a:focus {
+    text-decoration: underline;
+}
+
+@media (max-width: 900px) {
+    .site-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .header-actions {
+        width: 100%;
+        justify-content: flex-start;
+        flex-wrap: wrap;
+    }
+
+    .header-actions .button {
+        flex: 1 1 160px;
+    }
+
+    .user-card {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}
+
+@media (max-width: 640px) {
+    body {
+        padding: 32px 16px 48px;
+    }
+
+    .profile-summary,
+    .history,
+    .scores {
+        padding: 28px;
+    }
+
+    .table-header,
+    .table-row {
+        grid-template-columns: 1fr;
+    }
+}

--- a/pages/login.html
+++ b/pages/login.html
@@ -18,8 +18,11 @@
         <main>
             <section class="auth-card" aria-labelledby="login-title">
                 <div class="brand" aria-label="AutoServ">
-                    <div class="brand-icon" aria-hidden="true"></div>
-                    <span>AutoServ</span>
+                    <a class="brand-link" href="./paginainicio.html">
+                        <div class="brand-icon" aria-hidden="true"></div>
+                        <span>AutoServ</span>
+                    </a>
+                    <a class="back-home" href="./paginainicio.html">Volver al inicio</a>
                 </div>
 
                 <header class="auth-header">

--- a/pages/paginainicio.html
+++ b/pages/paginainicio.html
@@ -24,9 +24,12 @@
                 <a href="#inicio" class="nav-link active">Inicio</a>
                 <a href="#citas" class="nav-link">Citas</a>
                 <a href="#mensajes" class="nav-link">Mensajes</a>
-                <a href="#perfil" class="nav-link">Perfil</a>
+                <a href="./perfil.html" class="nav-link">Perfil</a>
             </nav>
-            <a href="#agendar" class="button button-primary">Agendar Cita</a>
+            <div class="header-actions">
+                <a href="#agendar" class="button button-primary">Agendar Cita</a>
+                <a href="./perfil.html" class="button ghost">Mi Perfil</a>
+            </div>
         </header>
 
         <main>
@@ -36,7 +39,7 @@
                     <span class="hero-tag">Tus Técnicos</span>
                     <h1>Confianza en Cada Reparación</h1>
                     <p>Tu Solución para el Mantenimiento Automotriz.</p>
-                    <a class="button" href="#perfil">Ver Perfil</a>
+                    <a class="button" href="./perfil.html">Ver Perfil</a>
                 </div>
             </section>
 

--- a/pages/perfil.html
+++ b/pages/perfil.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="es">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <title>Mechapp · Perfil de Usuario</title>
+        <meta name="description" content="Consulta los datos de tu cuenta y el historial de talleres visitados." />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap"
+            rel="stylesheet"
+        />
+        <link rel="stylesheet" href="../Styles/perfil.css" />
+    </head>
+    <body>
+        <header class="site-header">
+            <a class="brand" href="./paginainicio.html" aria-label="Volver al inicio">
+                <div class="brand-icon" aria-hidden="true"></div>
+                <span class="brand-name">Mechapp</span>
+            </a>
+            <div class="header-actions">
+                <a href="./paginainicio.html" class="button ghost">Inicio</a>
+                <a href="./login.html" class="button">Cerrar sesión</a>
+            </div>
+        </header>
+
+        <main>
+            <section class="profile-summary" aria-labelledby="profile-title">
+                <div class="user-card">
+                    <div class="avatar" aria-hidden="true">AR</div>
+                    <div class="user-details">
+                        <span class="label">Perfil</span>
+                        <h1 id="profile-title">Andrea Ramírez</h1>
+                        <p class="role">Cliente Premium</p>
+                        <dl class="user-meta">
+                            <div>
+                                <dt>Correo</dt>
+                                <dd>andrea.ramirez@email.com</dd>
+                            </div>
+                            <div>
+                                <dt>Teléfono</dt>
+                                <dd>+34 600 123 456</dd>
+                            </div>
+                            <div>
+                                <dt>Miembro desde</dt>
+                                <dd>Marzo 2021</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="metrics" aria-label="Indicadores de la cuenta">
+                    <article class="metric-card">
+                        <span class="metric-label">Citas completadas</span>
+                        <strong class="metric-value">28</strong>
+                        <span class="metric-caption">En los últimos 12 meses</span>
+                    </article>
+                    <article class="metric-card">
+                        <span class="metric-label">Puntuación promedio</span>
+                        <strong class="metric-value">4.9</strong>
+                        <span class="metric-caption">Basado en 18 reseñas</span>
+                    </article>
+                    <article class="metric-card">
+                        <span class="metric-label">Vehículos registrados</span>
+                        <strong class="metric-value">2</strong>
+                        <span class="metric-caption">Sedán 2020 · SUV 2022</span>
+                    </article>
+                </div>
+            </section>
+
+            <section class="history" id="historial" aria-labelledby="historial-title">
+                <div class="section-header">
+                    <div>
+                        <h2 id="historial-title">Historial de talleres visitados</h2>
+                        <p>Resumen de tus últimas experiencias en el taller.</p>
+                    </div>
+                    <a class="button ghost" href="#">Descargar historial</a>
+                </div>
+                <div class="history-list">
+                    <article class="history-item">
+                        <div>
+                            <h3>AutoMasters · Centro</h3>
+                            <p class="item-meta">Revisión general · 12 de abril de 2024</p>
+                        </div>
+                        <span class="status success">Completado</span>
+                    </article>
+                    <article class="history-item">
+                        <div>
+                            <h3>Taller Ruiz</h3>
+                            <p class="item-meta">Alineación y balanceo · 22 de febrero de 2024</p>
+                        </div>
+                        <span class="status success">Completado</span>
+                    </article>
+                    <article class="history-item">
+                        <div>
+                            <h3>ElectroAuto Norte</h3>
+                            <p class="item-meta">Diagnóstico eléctrico · 15 de enero de 2024</p>
+                        </div>
+                        <span class="status pending">Seguimiento</span>
+                    </article>
+                </div>
+            </section>
+
+            <section class="scores" id="puntuaciones" aria-labelledby="scores-title">
+                <div class="section-header">
+                    <div>
+                        <h2 id="scores-title">Puntuaciones y comentarios</h2>
+                        <p>Consulta las valoraciones que has dejado a los talleres.</p>
+                    </div>
+                    <a class="button ghost" href="#">Nueva reseña</a>
+                </div>
+                <div class="scores-table" role="table" aria-label="Historial de puntuaciones">
+                    <div class="table-header" role="row">
+                        <span role="columnheader">Taller</span>
+                        <span role="columnheader">Servicio</span>
+                        <span role="columnheader">Fecha</span>
+                        <span role="columnheader">Puntuación</span>
+                    </div>
+                    <div class="table-row" role="row">
+                        <span role="cell">AutoMasters · Centro</span>
+                        <span role="cell">Revisión general</span>
+                        <span role="cell">12/04/2024</span>
+                        <span role="cell" class="rating">5.0</span>
+                    </div>
+                    <div class="table-row" role="row">
+                        <span role="cell">Taller Ruiz</span>
+                        <span role="cell">Alineación y balanceo</span>
+                        <span role="cell">22/02/2024</span>
+                        <span role="cell" class="rating">4.8</span>
+                    </div>
+                    <div class="table-row" role="row">
+                        <span role="cell">ElectroAuto Norte</span>
+                        <span role="cell">Diagnóstico eléctrico</span>
+                        <span role="cell">15/01/2024</span>
+                        <span role="cell" class="rating">4.7</span>
+                    </div>
+                </div>
+            </section>
+        </main>
+
+        <footer class="site-footer">
+            <p>¿Necesitas ayuda? Escríbenos a <a href="mailto:soporte@autoserv.com">soporte@autoserv.com</a></p>
+        </footer>
+    </body>
+</html>


### PR DESCRIPTION
## Summary
- add navigation from the login screen back to the home page and adjust its styling
- update the home page navigation and header with links to the new user profile screen
- create a dedicated user profile page with account details, history and scores plus matching styles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9ec7ce868832da1f5eabed03dca36