### PR TITLE
Add client-side validation for authentication forms

### DIFF
--- a/Styles/auth.css
+++ b/Styles/auth.css
@@ -154,6 +154,51 @@ input:focus {
     box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.18);
 }
 
+input[aria-invalid="true"],
+select[aria-invalid="true"] {
+    border-color: rgba(248, 113, 113, 0.85);
+    box-shadow: 0 0 0 4px rgba(248, 113, 113, 0.22);
+}
+
+.error-message {
+    font-size: 0.85rem;
+    color: #fca5a5;
+    min-height: 1.25rem;
+}
+
+.password-rules {
+    list-style: none;
+    display: grid;
+    gap: 6px;
+    margin: 0;
+    padding: 0;
+    font-size: 0.85rem;
+    color: rgba(248, 250, 252, 0.75);
+}
+
+.password-rules li {
+    position: relative;
+    padding-left: 26px;
+}
+
+.password-rules li::before {
+    content: "✕";
+    position: absolute;
+    left: 0;
+    top: 0;
+    color: #f87171;
+    font-weight: 700;
+}
+
+.password-rules li.valid {
+    color: #bbf7d0;
+}
+
+.password-rules li.valid::before {
+    content: "✓";
+    color: #34d399;
+}
+
 input::placeholder {
     color: rgba(148, 163, 184, 0.75);
 }
@@ -199,6 +244,17 @@ input[type="file"] {
     transform: translateY(-1px);
     box-shadow: 0 18px 28px rgba(15, 23, 42, 0.3);
     background: var(--accent-dark);
+}
+
+.button[disabled],
+.button[disabled]:hover,
+.button[disabled]:focus {
+    background: rgba(248, 250, 252, 0.24);
+    color: rgba(15, 23, 42, 0.45);
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+    pointer-events: none;
 }
 .hint {
     font-size: 0.85rem;

--- a/pages/login.html
+++ b/pages/login.html
@@ -30,7 +30,7 @@
                     <p>Accede a tu cuenta para agendar citas, enviar mensajes y revisar tu historial.</p>
                 </header>
 
-                <form>
+                <form id="login-form" data-form="login" novalidate>
                     <div class="field">
                         <label for="email">Correo electrónico</label>
                         <input
@@ -40,7 +40,9 @@
                             placeholder="nombre@correo.com"
                             autocomplete="email"
                             required
+                            aria-describedby="login-email-error"
                         />
+                        <p class="error-message" id="login-email-error" aria-live="polite"></p>
                     </div>
                     <div class="field">
                         <label for="password">Contraseña</label>
@@ -51,7 +53,15 @@
                             placeholder="Ingresa tu contraseña"
                             autocomplete="current-password"
                             required
+                            aria-describedby="login-password-error"
                         />
+                        <ul class="password-rules" aria-live="polite">
+                            <li data-password-rule="length">Al menos 8 caracteres.</li>
+                            <li data-password-rule="uppercase">Incluye una letra mayúscula.</li>
+                            <li data-password-rule="lowercase">Incluye una letra minúscula.</li>
+                            <li data-password-rule="numberOrSymbol">Incluye un número o símbolo.</li>
+                        </ul>
+                        <p class="error-message" id="login-password-error" aria-live="polite"></p>
                     </div>
                     <div class="inline">
                         <label for="remember">
@@ -60,7 +70,7 @@
                         <a href="./recuperar-contrasena.html">¿Olvidaste tu contraseña?</a>
                     </div>
                     <div class="actions">
-                        <button type="submit" class="button">Iniciar sesión</button>
+                        <button type="submit" class="button" disabled aria-disabled="true">Iniciar sesión</button>
                     </div>
                 </form>
 
@@ -70,5 +80,6 @@
                 </div>
             </section>
         </main>
+        <script src="../src/auth-forms.js" defer></script>
     </body>
 </html>

--- a/pages/recuperar-contrasena.html
+++ b/pages/recuperar-contrasena.html
@@ -33,7 +33,7 @@
                     </p>
                 </header>
 
-                <form>
+                <form id="recovery-form" data-form="recovery" novalidate>
                     <div class="field">
                         <label for="recovery-email">Correo electrónico</label>
                         <input
@@ -43,10 +43,12 @@
                             placeholder="nombre@correo.com"
                             autocomplete="email"
                             required
+                            aria-describedby="recovery-email-error"
                         />
+                        <p class="error-message" id="recovery-email-error" aria-live="polite"></p>
                     </div>
                     <div class="actions">
-                        <button type="submit" class="button">Enviar instrucciones</button>
+                        <button type="submit" class="button" disabled aria-disabled="true">Enviar instrucciones</button>
                         <p class="hint">
                             Al enviar la solicitud recibirás un correo con los pasos para restablecer tu contraseña.
                         </p>
@@ -58,5 +60,6 @@
                 </div>
             </section>
         </main>
+        <script src="../src/auth-forms.js" defer></script>
     </body>
 </html>

--- a/pages/registro.html
+++ b/pages/registro.html
@@ -27,7 +27,7 @@
                     <p>Completa tus datos para empezar a agendar servicios y recibir soporte personalizado.</p>
                 </header>
 
-                <form>
+                <form id="register-form" data-form="register" novalidate>
                     <div class="field">
                         <label for="name">Nombre completo</label>
                         <input
@@ -37,7 +37,9 @@
                             placeholder="Tu nombre"
                             autocomplete="name"
                             required
+                            aria-describedby="register-name-error"
                         />
+                        <p class="error-message" id="register-name-error" aria-live="polite"></p>
                     </div>
                     <div class="field">
                         <label for="email">Correo electrónico</label>
@@ -48,7 +50,9 @@
                             placeholder="nombre@correo.com"
                             autocomplete="email"
                             required
+                            aria-describedby="register-email-error"
                         />
+                        <p class="error-message" id="register-email-error" aria-live="polite"></p>
                     </div>
                     <div class="field">
                         <label for="password">Contraseña</label>
@@ -59,7 +63,15 @@
                             placeholder="Crea una contraseña"
                             autocomplete="new-password"
                             required
+                            aria-describedby="register-password-error"
                         />
+                        <ul class="password-rules" aria-live="polite">
+                            <li data-password-rule="length">Al menos 8 caracteres.</li>
+                            <li data-password-rule="uppercase">Incluye una letra mayúscula.</li>
+                            <li data-password-rule="lowercase">Incluye una letra minúscula.</li>
+                            <li data-password-rule="numberOrSymbol">Incluye un número o símbolo.</li>
+                        </ul>
+                        <p class="error-message" id="register-password-error" aria-live="polite"></p>
                     </div>
                     <div class="field">
                         <label for="confirm-password">Confirmar contraseña</label>
@@ -70,15 +82,18 @@
                             placeholder="Repite tu contraseña"
                             autocomplete="new-password"
                             required
+                            aria-describedby="register-confirm-password-error"
                         />
+                        <p class="error-message" id="register-confirm-password-error" aria-live="polite"></p>
                     </div>
                     <div class="field">
                         <label for="account-type">Tipo de cuenta</label>
-                        <select id="account-type" name="account-type" required>
+                        <select id="account-type" name="account-type" required aria-describedby="register-account-type-error">
                             <option value="" disabled selected>Selecciona una opción</option>
                             <option value="cliente">Cliente</option>
                             <option value="mecanico">Mecánico</option>
                         </select>
+                        <p class="error-message" id="register-account-type-error" aria-live="polite"></p>
                     </div>
                     <div class="field hidden" id="certificate-field">
                         <label for="certificate">Certificado profesional (foto)</label>
@@ -87,11 +102,13 @@
                             id="certificate"
                             name="certificate"
                             accept="image/*"
+                            aria-describedby="register-certificate-error"
                         />
                         <p class="hint">Sube una foto legible de tu certificación como mecánico.</p>
+                        <p class="error-message" id="register-certificate-error" aria-live="polite"></p>
                     </div>
                     <div class="actions">
-                        <button type="submit" class="button">Registrarme</button>
+                        <button type="submit" class="button" disabled aria-disabled="true">Registrarme</button>
                     </div>
                 </form>
 
@@ -102,26 +119,6 @@
             </section>
         </main>
 
-        <script>
-            const accountType = document.getElementById("account-type");
-            const certificateField = document.getElementById("certificate-field");
-            const certificateInput = document.getElementById("certificate");
-
-            if (accountType) {
-                accountType.addEventListener("change", () => {
-                    const isMechanic = accountType.value === "mecanico";
-
-                    certificateField?.classList.toggle("hidden", !isMechanic);
-
-                    if (certificateInput) {
-                        certificateInput.required = isMechanic;
-
-                        if (!isMechanic) {
-                            certificateInput.value = "";
-                        }
-                    }
-                });
-            }
-        </script>
+        <script src="../src/auth-forms.js" defer></script>
     </body>
 </html>

--- a/src/auth-forms.js
+++ b/src/auth-forms.js
@@ -1,0 +1,304 @@
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const passwordRuleDefinitions = [
+    {
+        key: "length",
+        message: "La contraseña debe tener al menos 8 caracteres.",
+        test: (value) => value.length >= 8,
+    },
+    {
+        key: "uppercase",
+        message: "La contraseña debe incluir al menos una letra mayúscula.",
+        test: (value) => /[A-ZÁÉÍÓÚÜÑ]/.test(value),
+    },
+    {
+        key: "lowercase",
+        message: "La contraseña debe incluir al menos una letra minúscula.",
+        test: (value) => /[a-záéíóúüñ]/.test(value),
+    },
+    {
+        key: "numberOrSymbol",
+        message: "La contraseña debe incluir un número o símbolo.",
+        test: (value) => /(\d|[^A-Za-zÁÉÍÓÚÜÑáéíóúüñ\s])/.test(value),
+    },
+];
+
+const formConfigurations = {
+    login: {
+        fields: {
+            email: [
+                (value) => (!value ? "Ingresa tu correo electrónico." : null),
+                (value) => (value && emailPattern.test(value) ? null : "Ingresa un correo electrónico válido."),
+            ],
+            password: [passwordValidator],
+        },
+    },
+    register: {
+        fields: {
+            name: [
+                (value) => (!value ? "Ingresa tu nombre completo." : null),
+                (value) => (value && value.length >= 3 ? null : "Tu nombre debe tener al menos 3 caracteres."),
+            ],
+            email: [
+                (value) => (!value ? "Ingresa tu correo electrónico." : null),
+                (value) => (value && emailPattern.test(value) ? null : "Ingresa un correo electrónico válido."),
+            ],
+            password: [passwordValidator],
+            "confirm-password": [
+                (value) => (!value ? "Confirma tu contraseña." : null),
+                (value, form) => {
+                    const password = form.querySelector('input[name="password"]');
+                    const normalizedPassword = password ? getNormalizedValue(password) : "";
+                    if (password && value !== normalizedPassword) {
+                        return "Las contraseñas no coinciden.";
+                    }
+                    return null;
+                },
+            ],
+            "account-type": [
+                (value) => (!value ? "Selecciona un tipo de cuenta." : null),
+            ],
+            certificate: [
+                (value, form) => {
+                    const accountType = form.querySelector('#account-type');
+                    const isMechanic = accountType && accountType.value === "mecanico";
+                    if (!isMechanic) {
+                        return null;
+                    }
+
+                    const hasFile = value && value.length > 0;
+                    return hasFile ? null : "Adjunta tu certificación profesional.";
+                },
+            ],
+        },
+    },
+    recovery: {
+        fields: {
+            email: [
+                (value) => (!value ? "Ingresa tu correo electrónico." : null),
+                (value) => (value && emailPattern.test(value) ? null : "Ingresa un correo electrónico válido."),
+            ],
+        },
+    },
+};
+
+function passwordValidator(value) {
+    const errors = [];
+    if (!value) {
+        errors.push("Ingresa una contraseña.");
+        return errors;
+    }
+
+    passwordRuleDefinitions.forEach((rule) => {
+        if (!rule.test(value)) {
+            errors.push(rule.message);
+        }
+    });
+
+    return errors;
+}
+
+function normalizeErrors(result) {
+    if (!result) {
+        return [];
+    }
+
+    if (Array.isArray(result)) {
+        return result.filter(Boolean);
+    }
+
+    return [result];
+}
+
+function getNormalizedValue(field) {
+    if (!field) {
+        return "";
+    }
+
+    if (field.type === "file") {
+        return field.files;
+    }
+
+    if (field.type === "checkbox") {
+        return field.checked;
+    }
+
+    return field.value.trim();
+}
+
+function getFieldErrors(field, config) {
+    const fieldName = field?.getAttribute("name");
+    const validators = (fieldName && config.fields[fieldName]) || [];
+    const value = getNormalizedValue(field);
+    const form = field?.form;
+
+    return validators.flatMap((validator) => normalizeErrors(validator(value, form, field)));
+}
+
+function renderFieldErrors(field, errors, showErrors) {
+    const errorId = field.getAttribute("aria-describedby");
+    const errorContainer = errorId ? field.form?.querySelector(`#${errorId}`) : null;
+
+    if (errorContainer) {
+        errorContainer.textContent = showErrors ? errors.join(" ") : "";
+    }
+
+    const isInvalid = errors.length > 0;
+    field.setAttribute("aria-invalid", showErrors && isInvalid ? "true" : "false");
+}
+
+function updatePasswordRules(form, passwordValue) {
+    if (!form) {
+        return;
+    }
+
+    const ruleItems = form.querySelectorAll("[data-password-rule]");
+    if (!ruleItems.length) {
+        return;
+    }
+
+    const value = (passwordValue || "").trim();
+
+    passwordRuleDefinitions.forEach((rule) => {
+        const item = form.querySelector(`[data-password-rule="${rule.key}"]`);
+        if (item) {
+            item.classList.toggle("valid", rule.test(value));
+        }
+    });
+}
+
+function setupForm(form) {
+    const formType = form.dataset.form;
+    const config = formConfigurations[formType];
+
+    if (!config) {
+        return;
+    }
+
+    const submitButton = form.querySelector('button[type="submit"]');
+    const fieldEntries = Object.keys(config.fields).map((name) => {
+        const element = form.querySelector(`[name="${name}"]`);
+        return element || null;
+    });
+
+    const fields = fieldEntries.filter(Boolean);
+
+    const updateSubmitState = () => {
+        const allValid = fields.every((field) => getFieldErrors(field, config).length === 0);
+        if (submitButton) {
+            submitButton.disabled = !allValid;
+            submitButton.setAttribute("aria-disabled", submitButton.disabled ? "true" : "false");
+        }
+    };
+
+    const validateField = (field, { force = false } = {}) => {
+        if (!field) {
+            return [];
+        }
+
+        const errors = getFieldErrors(field, config);
+        const shouldShow = force || field.dataset.touched === "true";
+
+        if (field.getAttribute("name") === "password") {
+            const normalizedValue = getNormalizedValue(field);
+            const value = typeof normalizedValue === "string" ? normalizedValue : "";
+            updatePasswordRules(form, value);
+        }
+
+        renderFieldErrors(field, errors, shouldShow);
+        return errors;
+    };
+
+    fields.forEach((field) => {
+        field.setAttribute("aria-invalid", "false");
+
+        const isFile = field.type === "file";
+        const isSelect = field.tagName === "SELECT";
+        const eventType = isFile || isSelect ? "change" : "input";
+
+        field.addEventListener(eventType, () => {
+            if (!field.dataset.touched) {
+                field.dataset.touched = "true";
+            }
+
+            validateField(field, { force: field.dataset.touched === "true" });
+
+            if (field.getAttribute("name") === "password") {
+                const confirmField = form.querySelector('input[name="confirm-password"]');
+                if (confirmField) {
+                    validateField(confirmField, { force: confirmField.dataset.touched === "true" });
+                }
+            }
+
+            updateSubmitState();
+        });
+
+        field.addEventListener("blur", () => {
+            field.dataset.touched = "true";
+            validateField(field, { force: true });
+            updateSubmitState();
+        });
+
+        if (field.getAttribute("name") === "password") {
+            const normalizedValue = getNormalizedValue(field);
+            const value = typeof normalizedValue === "string" ? normalizedValue : "";
+            updatePasswordRules(form, value);
+        }
+    });
+
+    updateSubmitState();
+
+    form.addEventListener("submit", (event) => {
+        const invalidFields = fields.filter((field) => validateField(field, { force: true }).length > 0);
+
+        if (invalidFields.length > 0) {
+            event.preventDefault();
+            invalidFields[0]?.focus();
+        }
+    });
+
+    if (formType === "register") {
+        setupRegisterExtras(form, config, fields, validateField, updateSubmitState);
+    }
+}
+
+function setupRegisterExtras(form, config, fields, validateField, updateSubmitState) {
+    const accountTypeField = form.querySelector("#account-type");
+    const certificateFieldWrapper = form.querySelector("#certificate-field");
+    const certificateInput = form.querySelector("#certificate");
+
+    const toggleCertificate = () => {
+        const isMechanic = accountTypeField?.value === "mecanico";
+
+        certificateFieldWrapper?.classList.toggle("hidden", !isMechanic);
+
+        if (certificateInput) {
+            certificateInput.required = Boolean(isMechanic);
+            if (!isMechanic) {
+                certificateInput.value = "";
+            }
+            validateField(certificateInput, { force: certificateInput.dataset.touched === "true" });
+        }
+
+        updateSubmitState();
+    };
+
+    if (accountTypeField) {
+        accountTypeField.addEventListener("change", () => {
+            accountTypeField.dataset.touched = "true";
+            validateField(accountTypeField, { force: true });
+            toggleCertificate();
+        });
+
+        toggleCertificate();
+    }
+
+    if (certificateInput && !fields.includes(certificateInput)) {
+        fields.push(certificateInput);
+    }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    const forms = document.querySelectorAll("form[data-form]");
+    forms.forEach((form) => setupForm(form));
+});


### PR DESCRIPTION
## Summary
- add a shared script that validates the login, registro, and recuperación de contraseña forms and keeps the submit button disabled until the inputs are correct
- surface inline error messaging and password requirement indicators with updated styling for invalid fields and disabled buttons

## Testing
- Not run (static changes)


------
https://chatgpt.com/codex/tasks/task_e_68d9ee8f8058832da2e08a672236501b