### PR TITLE
Add login CTA and custom logo to home page

### DIFF
--- a/Styles/paginainicio.css
+++ b/Styles/paginainicio.css
@@ -57,20 +57,11 @@ main {
     font-size: 1.25rem;
 }
 
-.brand-icon {
-    width: 36px;
-    height: 36px;
-    border-radius: 12px;
-    background: linear-gradient(135deg, #38bdf8, #6366f1);
-    position: relative;
-}
-
-.brand-icon::after {
-    content: "";
-    position: absolute;
-    inset: 8px;
-    border-radius: 8px;
-    border: 2px solid rgba(255, 255, 255, 0.6);
+.brand-logo {
+    width: 40px;
+    height: 40px;
+    display: inline-block;
+    object-fit: contain;
 }
 
 .main-nav {
@@ -138,6 +129,17 @@ main {
 .button-primary:hover,
 .button-primary:focus {
     background: var(--accent-dark);
+}
+
+.button-secondary {
+    background: rgba(255, 255, 255, 0.08);
+    color: #fff;
+    border-color: rgba(255, 255, 255, 0.24);
+}
+
+.button-secondary:hover,
+.button-secondary:focus {
+    background: rgba(255, 255, 255, 0.16);
 }
 
 .button.ghost {

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+    <title id="title">Logotipo de Mechapp</title>
+    <defs>
+        <linearGradient id="gearGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#0c2d41" />
+            <stop offset="100%" stop-color="#152f3f" />
+        </linearGradient>
+    </defs>
+    <g fill="url(#gearGradient)">
+        <path d="M50.6 8.6 54 22.8a32.7 32.7 0 0 1 20 0l3.4-14.2 12.3 4.4-3.4 14.1a32.5 32.5 0 0 1 14 14.1l14.1-3.4 4.4 12.3-14.2 3.4a32.7 32.7 0 0 1 0 20l14.2 3.4-4.4 12.3-14.1-3.4a32.5 32.5 0 0 1-14.1 14l3.4 14.2-12.3 4.4-3.4-14.2a32.7 32.7 0 0 1-20 0l-3.4 14.2-12.3-4.4 3.4-14.2a32.5 32.5 0 0 1-14-14.1l-14.2 3.4-4.4-12.3 14.2-3.4a32.7 32.7 0 0 1 0-20l-14.2-3.4 4.4-12.3 14.2 3.4a32.5 32.5 0 0 1 14-14.1L38.3 13z" />
+        <circle cx="64" cy="64" r="26" fill="#0d3142" />
+    </g>
+    <path
+        d="M56.2 79.6 42.8 66.2a6 6 0 0 1 8.4-8.4l8.5 8.5 24.7-24.7a6 6 0 0 1 8.4 8.4L64.6 81.3a6 6 0 0 1-8.4 0z"
+        fill="#f59e0b"
+    />
+</svg>

--- a/pages/paginainicio.html
+++ b/pages/paginainicio.html
@@ -23,7 +23,7 @@
     <body>
         <header class="site-header">
             <div class="brand">
-                <div class="brand-icon" aria-hidden="true"></div>
+                <img src="../assets/logo.svg" alt="Mechapp" class="brand-logo" />
                 <span class="brand-name">Mechapp</span>
             </div>
             <nav class="main-nav" aria-label="Principal">
@@ -35,6 +35,7 @@
                 <a href="./registro-taller.html" class="nav-link">Registrar Taller</a>
             </nav>
             <div class="header-actions">
+                <a href="./login.html" class="button button-secondary">Iniciar sesión</a>
                 <a href="#agendar" class="button button-primary">Agendar Cita</a>
                 <a href="./perfil.html" class="button ghost">Mi Perfil</a>
                 <a href="./registro-taller.html" class="button ghost">Registrar Taller</a>


### PR DESCRIPTION
## Summary
- replace the placeholder brand icon with the official Mechapp logo asset on the landing page header
- add a styled "Iniciar sesión" button to the header action area for quick access to the login screen

## Testing
- npm install *(fails: registry returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68db39f5abf4832d848124ff22a8d14a