### PR TITLE
Add newsletter subscription form to profile page

### DIFF
--- a/Styles/perfil.css
+++ b/Styles/perfil.css
@@ -109,9 +109,11 @@ main {
     border-radius: var(--radius-lg);
     padding: 40px;
     display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     gap: 28px;
     box-shadow: 0 24px 48px rgba(15, 23, 42, 0.18);
     position: relative;
+    align-items: stretch;
 }
 
 .profile-summary::after {
@@ -127,6 +129,7 @@ main {
     display: flex;
     gap: 24px;
     align-items: center;
+    grid-column: 1 / -1;
 }
 
 .avatar {
@@ -181,6 +184,64 @@ main {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     gap: 20px;
+}
+
+.subscription-card {
+    background: var(--surface-alt);
+    border-radius: var(--radius-md);
+    padding: 28px;
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    justify-content: center;
+}
+
+.subscription-card h2 {
+    font-size: 1.25rem;
+    font-weight: 700;
+}
+
+.subscription-card p {
+    color: var(--text-muted);
+    line-height: 1.5;
+}
+
+.subscription-form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.subscription-label {
+    font-weight: 600;
+    font-size: 0.9rem;
+    color: var(--text);
+}
+
+.subscription-input-group {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+}
+
+.subscription-input-group input {
+    flex: 1;
+    padding: 12px 16px;
+    border-radius: 999px;
+    border: 1px solid rgba(15, 23, 42, 0.16);
+    font-family: inherit;
+    font-size: 1rem;
+}
+
+.subscription-input-group input:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.2);
+}
+
+.subscription-note {
+    font-size: 0.85rem;
 }
 
 .metric-card {
@@ -366,5 +427,14 @@ main {
     .table-header,
     .table-row {
         grid-template-columns: 1fr;
+    }
+
+    .subscription-input-group {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .subscription-input-group .button {
+        width: 100%;
     }
 }

--- a/pages/perfil.html
+++ b/pages/perfil.html
@@ -63,6 +63,25 @@
                         <span class="metric-caption">Sedán 2020 · SUV 2022</span>
                     </article>
                 </div>
+                <aside class="subscription-card" aria-label="Formulario de suscripción a novedades">
+                    <h2>Suscríbete y recibe novedades</h2>
+                    <p>Mantente al día con promociones, recordatorios y novedades personalizadas.</p>
+                    <form class="subscription-form" action="#" method="post">
+                        <label class="subscription-label" for="subscription-email">Correo electrónico</label>
+                        <div class="subscription-input-group">
+                            <input
+                                type="email"
+                                id="subscription-email"
+                                name="subscription-email"
+                                placeholder="tucorreo@ejemplo.com"
+                                required
+                                autocomplete="email"
+                            />
+                            <button type="submit" class="button">Suscribirme</button>
+                        </div>
+                        <p class="subscription-note">Puedes darte de baja cuando quieras desde cualquier correo que recibas.</p>
+                    </form>
+                </aside>
             </section>
 
             <section class="history" id="historial" aria-labelledby="historial-title">


### PR DESCRIPTION
## Summary
- add a subscription card to the profile page so users can request email updates
- extend the profile styles to lay out the new card alongside existing metrics and handle smaller screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e45446c468832dbaf05c9595677996