### PR TITLE
Enable EmailJS subscription form on profile page

### DIFF
--- a/Styles/perfil.css
+++ b/Styles/perfil.css
@@ -244,6 +244,19 @@ main {
     font-size: 0.85rem;
 }
 
+.subscription-feedback {
+    font-size: 0.9rem;
+    line-height: 1.4;
+}
+
+.subscription-feedback.success {
+    color: #16a34a;
+}
+
+.subscription-feedback.error {
+    color: #dc2626;
+}
+
 .metric-card {
     background: var(--surface-alt);
     border-radius: var(--radius-md);

--- a/pages/perfil.html
+++ b/pages/perfil.html
@@ -66,7 +66,14 @@
                 <aside class="subscription-card" aria-label="Formulario de suscripción a novedades">
                     <h2>Suscríbete y recibe novedades</h2>
                     <p>Mantente al día con promociones, recordatorios y novedades personalizadas.</p>
-                    <form class="subscription-form" action="#" method="post">
+                    <form
+                        class="subscription-form"
+                        action="#"
+                        method="post"
+                        data-emailjs-service-id=""
+                        data-emailjs-template-id=""
+                        data-emailjs-public-key=""
+                    >
                         <label class="subscription-label" for="subscription-email">Correo electrónico</label>
                         <div class="subscription-input-group">
                             <input
@@ -79,6 +86,7 @@
                             />
                             <button type="submit" class="button">Suscribirme</button>
                         </div>
+                        <p class="subscription-feedback" data-subscription-feedback role="status" hidden></p>
                         <p class="subscription-note">Puedes darte de baja cuando quieras desde cualquier correo que recibas.</p>
                     </form>
                 </aside>
@@ -157,6 +165,7 @@
         <footer class="site-footer">
             <p>¿Necesitas ayuda? Escríbenos a <a href="mailto:soporte@autoserv.com">soporte@autoserv.com</a></p>
         </footer>
+        <script src="https://cdn.jsdelivr.net/npm/@emailjs/browser@4/dist/email.min.js" defer></script>
         <script src="../src/profile.js" defer></script>
     </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -45,7 +45,7 @@ app.use(helmet({
       'default-src': ["'self'"],
 
       // Scripts locales + unpkg (Leaflet) + inline (tu script en la página)
-      'script-src': ["'self'", "'unsafe-inline'", 'https://unpkg.com'],
+      'script-src': ["'self'", "'unsafe-inline'", 'https://unpkg.com', 'https://cdn.jsdelivr.net'],
 
       // Estilos locales + unpkg + Google Fonts; permitir inline para estilos embebidos
       'style-src': ["'self'", "'unsafe-inline'", 'https://unpkg.com', 'https://fonts.googleapis.com'],
@@ -63,7 +63,7 @@ app.use(helmet({
       'font-src': ["'self'", 'https://fonts.gstatic.com'],
 
       // Permitir fetch/XHR a tu propio servidor y (opcional) a unpkg (para sourcemaps)
-      'connect-src': ["'self'", 'https://unpkg.com'],
+      'connect-src': ["'self'", 'https://unpkg.com', 'https://api.emailjs.com'],
     },
   },
   crossOriginResourcePolicy: { policy: 'cross-origin' },

--- a/src/profile.js
+++ b/src/profile.js
@@ -109,8 +109,91 @@ async function handleLogout() {
     }
 }
 
+function showSubscriptionFeedback(element, message, type = "success") {
+    if (!element) {
+        return;
+    }
+
+    element.textContent = message;
+    element.hidden = false;
+    element.classList.remove("success", "error");
+    element.classList.add(type);
+}
+
+function setupSubscriptionForm() {
+    const form = document.querySelector(".subscription-form");
+    if (!form) {
+        return;
+    }
+
+    const feedbackElement = form.querySelector("[data-subscription-feedback]");
+    const submitButton = form.querySelector('button[type="submit"]');
+    const emailInput = form.querySelector('input[type="email"]');
+
+    if (!submitButton || !emailInput) {
+        console.warn("El formulario de suscripción no tiene los elementos esperados.");
+        return;
+    }
+    const { emailjsServiceId: serviceId, emailjsTemplateId: templateId, emailjsPublicKey: publicKey } =
+        form.dataset;
+
+    if (!window.emailjs) {
+        console.error("La librería de EmailJS no está disponible. Verifica que el script se esté cargando correctamente.");
+        showSubscriptionFeedback(
+            feedbackElement,
+            "No se pudo cargar el servicio de suscripción. Intenta nuevamente en unos minutos.",
+            "error",
+        );
+        return;
+    }
+
+    if (!serviceId || !templateId || !publicKey) {
+        console.warn(
+            "Faltan credenciales de EmailJS. Asegúrate de definir data-emailjs-service-id, data-emailjs-template-id y data-emailjs-public-key en el formulario.",
+        );
+        return;
+    }
+
+    emailjs.init({ publicKey });
+
+    form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+
+        if (!emailInput || !form.reportValidity()) {
+            return;
+        }
+
+        submitButton.disabled = true;
+        showSubscriptionFeedback(feedbackElement, "Enviando tu suscripción...", "success");
+
+        try {
+            await emailjs.send(serviceId, templateId, {
+                subscriber_email: emailInput.value,
+            });
+
+            showSubscriptionFeedback(
+                feedbackElement,
+                "¡Listo! Revisa tu bandeja de entrada para confirmar la suscripción.",
+                "success",
+            );
+            form.reset();
+            emailInput.focus();
+        } catch (error) {
+            console.error("No se pudo enviar la suscripción", error);
+            showSubscriptionFeedback(
+                feedbackElement,
+                "No se pudo completar la suscripción. Inténtalo nuevamente más tarde.",
+                "error",
+            );
+        } finally {
+            submitButton.disabled = false;
+        }
+    });
+}
+
 document.addEventListener("DOMContentLoaded", () => {
     setupProfilePage();
+    setupSubscriptionForm();
 
     const logoutButton = document.getElementById("logout-button");
     if (logoutButton) {


### PR DESCRIPTION
## Summary
- wire up the subscription form on the profile page to EmailJS using the browser SDK
- add user feedback messaging and disable the submit button while sending
- include basic styling hooks for success and error states in the subscription card

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e58bfe3ca8832db8b415009b42502a