### PR TITLE
Add profile update workflows for account settings

### DIFF
--- a/Styles/auth.css
+++ b/Styles/auth.css
@@ -233,6 +233,24 @@ input[type="file"] {
     background: rgba(22, 101, 52, 0.45);
 }
 
+.form-feedback {
+    font-size: 0.95rem;
+    line-height: 1.4;
+    min-height: 1.25rem;
+}
+
+.form-feedback.success {
+    color: #bbf7d0;
+}
+
+.form-feedback.error {
+    color: #fca5a5;
+}
+
+.form-feedback.info {
+    color: rgba(248, 250, 252, 0.85);
+}
+
 .button {
     display: inline-flex;
     align-items: center;

--- a/Styles/perfil.css
+++ b/Styles/perfil.css
@@ -150,6 +150,25 @@ main {
     gap: 12px;
 }
 
+.profile-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 12px;
+}
+
+.profile-actions .button {
+    background: rgba(99, 102, 241, 0.12);
+    color: var(--text);
+    border: 1px solid rgba(99, 102, 241, 0.4);
+}
+
+.profile-actions .button:hover,
+.profile-actions .button:focus {
+    background: rgba(99, 102, 241, 0.18);
+    box-shadow: 0 12px 24px rgba(99, 102, 241, 0.2);
+}
+
 .label {
     text-transform: uppercase;
     letter-spacing: 0.18em;

--- a/pages/cambiar-contrasena.html
+++ b/pages/cambiar-contrasena.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="es">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <title>Mechapp · Cambiar contraseña</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="description" content="Actualiza la contraseña de tu cuenta de Mechapp de forma segura." />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap"
+            rel="stylesheet"
+        />
+        <link rel="stylesheet" href="../Styles/auth.css" />
+    </head>
+    <body>
+        <main>
+            <section class="auth-card" aria-labelledby="update-password-title">
+                <div class="brand" aria-label="Mechapp">
+                    <a class="brand-link" href="./paginainicio.html">
+                        <div class="brand-icon" aria-hidden="true"></div>
+                        <span>Mechapp</span>
+                    </a>
+                    <a class="back-home" href="./perfil.html">Volver al perfil</a>
+                </div>
+
+                <header class="auth-header">
+                    <h1 id="update-password-title">Actualiza tu contraseña</h1>
+                    <p>Elige una contraseña segura para proteger tu cuenta.</p>
+                </header>
+
+                <form data-update-form data-update-type="password">
+                    <div class="field">
+                        <label for="current-password">Contraseña actual</label>
+                        <input
+                            type="password"
+                            id="current-password"
+                            name="currentPassword"
+                            placeholder="Contraseña actual"
+                            autocomplete="current-password"
+                            required
+                        />
+                    </div>
+
+                    <div class="field">
+                        <label for="new-password">Nueva contraseña</label>
+                        <input
+                            type="password"
+                            id="new-password"
+                            name="newPassword"
+                            placeholder="Nueva contraseña"
+                            autocomplete="new-password"
+                            required
+                        />
+                        <ul class="password-rules">
+                            <li>Al menos 8 caracteres.</li>
+                            <li>Combina letras, números y símbolos para mayor seguridad.</li>
+                        </ul>
+                    </div>
+
+                    <div class="field">
+                        <label for="confirm-password">Confirmar nueva contraseña</label>
+                        <input
+                            type="password"
+                            id="confirm-password"
+                            name="confirmPassword"
+                            placeholder="Repite la nueva contraseña"
+                            autocomplete="new-password"
+                            required
+                        />
+                    </div>
+
+                    <button type="submit" class="button">Guardar cambios</button>
+                    <p class="form-feedback info" data-feedback aria-live="polite" hidden></p>
+                </form>
+            </section>
+        </main>
+
+        <script src="../src/profile-update.js" defer></script>
+    </body>
+</html>

--- a/pages/editar-correo.html
+++ b/pages/editar-correo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="es">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <title>Mechapp · Cambiar correo</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="description" content="Actualiza el correo electrónico asociado a tu cuenta de Mechapp." />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap"
+            rel="stylesheet"
+        />
+        <link rel="stylesheet" href="../Styles/auth.css" />
+    </head>
+    <body>
+        <main>
+            <section class="auth-card" aria-labelledby="update-email-title">
+                <div class="brand" aria-label="Mechapp">
+                    <a class="brand-link" href="./paginainicio.html">
+                        <div class="brand-icon" aria-hidden="true"></div>
+                        <span>Mechapp</span>
+                    </a>
+                    <a class="back-home" href="./perfil.html">Volver al perfil</a>
+                </div>
+
+                <header class="auth-header">
+                    <h1 id="update-email-title">Actualiza tu correo electrónico</h1>
+                    <p>Usaremos este correo para enviarte notificaciones y confirmar tus solicitudes.</p>
+                </header>
+
+                <form data-update-form data-update-type="email">
+                    <div class="field">
+                        <label for="email">Nuevo correo electrónico</label>
+                        <input
+                            type="email"
+                            id="email"
+                            name="email"
+                            placeholder="nombre@correo.com"
+                            autocomplete="email"
+                            required
+                        />
+                    </div>
+
+                    <button type="submit" class="button">Guardar cambios</button>
+                    <p class="form-feedback info" data-feedback aria-live="polite" hidden></p>
+                </form>
+            </section>
+        </main>
+
+        <script src="../src/profile-update.js" defer></script>
+    </body>
+</html>

--- a/pages/editar-nombre.html
+++ b/pages/editar-nombre.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="es">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <title>Mechapp · Cambiar nombre</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="description" content="Actualiza el nombre que se muestra en tu perfil de Mechapp." />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap"
+            rel="stylesheet"
+        />
+        <link rel="stylesheet" href="../Styles/auth.css" />
+    </head>
+    <body>
+        <main>
+            <section class="auth-card" aria-labelledby="update-name-title">
+                <div class="brand" aria-label="Mechapp">
+                    <a class="brand-link" href="./paginainicio.html">
+                        <div class="brand-icon" aria-hidden="true"></div>
+                        <span>Mechapp</span>
+                    </a>
+                    <a class="back-home" href="./perfil.html">Volver al perfil</a>
+                </div>
+
+                <header class="auth-header">
+                    <h1 id="update-name-title">Actualiza tu nombre</h1>
+                    <p>Modifica cómo aparece tu nombre en el perfil y en tus reservas.</p>
+                </header>
+
+                <form data-update-form data-update-type="name">
+                    <div class="field">
+                        <label for="name">Nuevo nombre completo</label>
+                        <input
+                            type="text"
+                            id="name"
+                            name="name"
+                            placeholder="Tu nombre"
+                            autocomplete="name"
+                            required
+                        />
+                    </div>
+
+                    <button type="submit" class="button">Guardar cambios</button>
+                    <p class="form-feedback info" data-feedback aria-live="polite" hidden></p>
+                </form>
+            </section>
+        </main>
+
+        <script src="../src/profile-update.js" defer></script>
+    </body>
+</html>

--- a/pages/perfil.html
+++ b/pages/perfil.html
@@ -43,6 +43,11 @@
                             <dd data-profile-member-since></dd>
                         </div>
                     </dl>
+                    <div class="profile-actions" aria-label="Acciones de la cuenta">
+                        <a class="button" href="./editar-nombre.html">Cambiar nombre</a>
+                        <a class="button" href="./editar-correo.html">Cambiar correo</a>
+                        <a class="button" href="./cambiar-contrasena.html">Cambiar contraseña</a>
+                    </div>
                 </div>
             </div>
 

--- a/src/profile-update.js
+++ b/src/profile-update.js
@@ -1,0 +1,209 @@
+async function fetchProfileOrRedirect() {
+    const response = await fetch("/api/profile");
+
+    if (response.status === 401) {
+        window.location.href = "./login.html";
+        return null;
+    }
+
+    if (!response.ok) {
+        throw new Error("No se pudo obtener la información del perfil.");
+    }
+
+    return response.json();
+}
+
+function showFeedback(element, message, type = "info") {
+    if (!element) {
+        return;
+    }
+
+    element.textContent = message;
+    element.classList.remove("success", "error", "info");
+    element.classList.add(type);
+    element.hidden = false;
+}
+
+function clearFeedback(element) {
+    if (!element) {
+        return;
+    }
+
+    element.textContent = "";
+    element.classList.remove("success", "error", "info");
+    element.classList.add("info");
+    element.hidden = true;
+}
+
+function handleUnauthorized(response) {
+    if (response.status === 401) {
+        window.location.href = "./login.html";
+        return true;
+    }
+    return false;
+}
+
+async function initializeForm() {
+    const form = document.querySelector("[data-update-form]");
+
+    if (!form) {
+        return;
+    }
+
+    const updateType = form.dataset.updateType;
+    const feedbackElement = document.querySelector("[data-feedback]");
+    const submitButton = form.querySelector('button[type="submit"]');
+
+    clearFeedback(feedbackElement);
+
+    if (updateType === "name" || updateType === "email") {
+        try {
+            const profile = await fetchProfileOrRedirect();
+            if (!profile) {
+                return;
+            }
+
+            if (updateType === "name") {
+                const nameInput = form.querySelector('input[name="name"]');
+                if (nameInput) {
+                    nameInput.value = profile.name || "";
+                }
+            } else if (updateType === "email") {
+                const emailInput = form.querySelector('input[name="email"]');
+                if (emailInput) {
+                    emailInput.value = profile.email || "";
+                }
+            }
+        } catch (error) {
+            console.error(error);
+            showFeedback(feedbackElement, "No se pudo cargar la información del perfil.", "error");
+            return;
+        }
+    }
+
+    form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+
+        if (!submitButton) {
+            return;
+        }
+
+        let endpoint = "";
+        let payload = {};
+
+        switch (updateType) {
+            case "name": {
+                const nameInput = form.querySelector('input[name="name"]');
+                const trimmedName = String(nameInput?.value || "").trim();
+
+                if (!trimmedName) {
+                    showFeedback(feedbackElement, "Ingresa un nombre válido.", "error");
+                    nameInput?.focus();
+                    return;
+                }
+
+                endpoint = "/api/profile/name";
+                payload = { name: trimmedName };
+                break;
+            }
+            case "email": {
+                const emailInput = form.querySelector('input[name="email"]');
+                const normalizedEmail = String(emailInput?.value || "").trim().toLowerCase();
+                const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+                if (!normalizedEmail || !emailRegex.test(normalizedEmail)) {
+                    showFeedback(feedbackElement, "Ingresa un correo electrónico válido.", "error");
+                    emailInput?.focus();
+                    return;
+                }
+
+                endpoint = "/api/profile/email";
+                payload = { email: normalizedEmail };
+                break;
+            }
+            case "password": {
+                const currentPasswordInput = form.querySelector('input[name="currentPassword"]');
+                const newPasswordInput = form.querySelector('input[name="newPassword"]');
+                const confirmPasswordInput = form.querySelector('input[name="confirmPassword"]');
+
+                const currentPassword = String(currentPasswordInput?.value || "");
+                const newPassword = String(newPasswordInput?.value || "");
+                const confirmPassword = String(confirmPasswordInput?.value || "");
+
+                if (!currentPassword) {
+                    showFeedback(feedbackElement, "Ingresa tu contraseña actual.", "error");
+                    currentPasswordInput?.focus();
+                    return;
+                }
+
+                if (newPassword.length < 8) {
+                    showFeedback(feedbackElement, "La nueva contraseña debe tener al menos 8 caracteres.", "error");
+                    newPasswordInput?.focus();
+                    return;
+                }
+
+                if (newPassword !== confirmPassword) {
+                    showFeedback(feedbackElement, "La confirmación no coincide con la nueva contraseña.", "error");
+                    confirmPasswordInput?.focus();
+                    return;
+                }
+
+                endpoint = "/api/profile/password";
+                payload = { currentPassword, newPassword };
+                break;
+            }
+            default:
+                console.warn("Tipo de actualización no soportado:", updateType);
+                return;
+        }
+
+        try {
+            submitButton.disabled = true;
+            showFeedback(feedbackElement, "Guardando cambios...", "info");
+
+            const response = await fetch(endpoint, {
+                method: "PUT",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify(payload),
+            });
+
+            if (handleUnauthorized(response)) {
+                return;
+            }
+
+            let data = {};
+            try {
+                data = await response.json();
+            } catch (error) {
+                // Ignorar errores de parseo y usar mensajes genéricos.
+            }
+
+            if (!response.ok) {
+                const errorMessage = data.error || "No se pudo guardar el cambio. Intenta de nuevo.";
+                showFeedback(feedbackElement, errorMessage, "error");
+                return;
+            }
+
+            showFeedback(feedbackElement, data.message || "Cambios guardados correctamente.", "success");
+
+            if (updateType === "password") {
+                form.reset();
+            }
+
+            setTimeout(() => {
+                window.location.href = "./perfil.html";
+            }, 1500);
+        } catch (error) {
+            console.error(error);
+            showFeedback(feedbackElement, "No se pudo completar la solicitud. Verifica tu conexión e inténtalo nuevamente.", "error");
+        } finally {
+            submitButton.disabled = false;
+        }
+    });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    initializeForm();
+});


### PR DESCRIPTION
## Summary
- add protected API endpoints to update the profile name, email, and password with validation and proper errors
- surface profile management actions and dedicated forms for updating account data
- share client-side logic to prellenar datos actuales, validar entradas y confirmar el guardado antes de volver al perfil

## Testing
- node --check server.js

------
https://chatgpt.com/codex/tasks/task_e_68e5bf8e61f8832d83e432feee326f3e