### PR TITLE
Fix profile update redirect logic

### DIFF
--- a/src/profile-update.js
+++ b/src/profile-update.js
@@ -83,9 +83,6 @@ async function initializeForm() {
 
  
     let redirecting = false;
-
-
-
     form.addEventListener("submit", async (event) => {
         event.preventDefault();
 
@@ -197,14 +194,10 @@ async function initializeForm() {
                 form.reset();
             }
 
-<<<<<<< HEAD
- 
-=======
-
             redirecting = true;
             setTimeout(() => {
                 window.location.replace("./perfil.html");
-            }, 0);
+            }, 1500);
             return;
         } catch (error) {
             console.error(error);
@@ -212,21 +205,6 @@ async function initializeForm() {
             if (redirecting && (error?.name === "AbortError" || error?.message === "Failed to fetch" || error?.message === "The user aborted a request.")) {
                 return;
             }
-
-
->>>>>>> 790dec9f7b2ecfe6cb146c67ee00453ea7f68275
-            window.location.replace("./perfil.html");
-
-            setTimeout(() => {
-                window.location.href = "./perfil.html";
-            }, 1500);
-<<<<<<< HEAD
- 
-=======
-
->>>>>>> 790dec9f7b2ecfe6cb146c67ee00453ea7f68275
-        } catch (error) {
-            console.error(error);
 
             showFeedback(feedbackElement, "No se pudo completar la solicitud. Verifica tu conexión e inténtalo nuevamente.", "error");
         } finally {


### PR DESCRIPTION
## Summary
- resolve merge conflicts in the profile update helper by removing duplicated redirects
- redirect back to the profile page after a short delay so the success feedback is visible
- keep aborted fetches from surfacing errors once the redirect begins

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5d06f16f0832d92f8c5b6f0237941